### PR TITLE
Create Amplify domain if specified

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
           [
             "--max-line-length=200",
             "--ignore=E203,W503",
-            "--max-cognitive-complexity=17",
+            "--max-cognitive-complexity=18",
             "--max-expression-complexity=9",
           ]
         additional_dependencies: [


### PR DESCRIPTION
cdk.json contains a `context.Prod.custom_domain.domain_name` config parameter, but without this PR it's not actually creating the Amplify domain.

---

Declaration : _By submitting this pull request, I confirm that my
contribution is made under the terms of the Apache-2.0 license_
