### PR TITLE
Paginate list_requests DynamoDb.scan

### DIFF
--- a/egress_backend/lambda/egress_api/list_requests.py
+++ b/egress_backend/lambda/egress_api/list_requests.py
@@ -21,6 +21,10 @@ def list_requests():
     ddb_table = ddb.Table(table)
 
     response = ddb_table.scan()
+    data = response["Items"]
+    while response.get("LastEvaluatedKey"):
+        response = ddb_table.scan(ExclusiveStartKey=response["LastEvaluatedKey"])
+        data.extend(response["Items"])
 
-    logger.debug("Succesful database scan of all egress requests")
-    return response["Items"]
+    logger.debug("Successful database scan of all egress requests")
+    return data


### PR DESCRIPTION
# Description

DynamoDB has a 1MB limit on responses. Pagination is needed for scanning larger tables.
https://stackoverflow.com/questions/36780856/complete-scan-of-dynamodb-with-boto3/38619425#38619425

---

Declaration : _By submitting this pull request, I confirm that my
contribution is made under the terms of the Apache-2.0 license_
