### PR TITLE
Ignore egress requests updated more than 90 days ago

### DIFF
--- a/egress_backend/lambda/egress_api/list_requests.py
+++ b/egress_backend/lambda/egress_api/list_requests.py
@@ -21,6 +21,10 @@ def list_requests():
     ddb_table = ddb.Table(table)
 
     response = ddb_table.scan()
+    data = response["Items"]
+    while response.get("LastEvaluatedKey"):
+        response = ddb_table.scan(ExclusiveStartKey=response["LastEvaluatedKey"])
+        data.extend(response["Items"])
 
-    logger.debug("Succesful database scan of all egress requests")
-    return response["Items"]
+    logger.debug("Successful database scan of all egress requests")
+    return data

--- a/egress_backend/lambda/egress_api/list_requests.py
+++ b/egress_backend/lambda/egress_api/list_requests.py
@@ -4,9 +4,12 @@
 # agreement between Customer and Amazon Web Services, Inc.
 
 import os
+from datetime import datetime
 
 import boto3
 from aws_lambda_powertools import Logger, Tracer
+
+MAX_REQUEST_AGE_DAYS = 90
 
 tracer = Tracer(service="ListRequestsAPI")
 logger = Logger(service="ListRequestsAPI")
@@ -18,13 +21,19 @@ table = os.environ["TABLE"]
 def list_requests():
     logger.debug("List Requests API invoked")
 
+    now = datetime.now()
+
+    def is_recent(item):
+        updated_dt = datetime.strptime(item["updated_dt"], "%Y-%m-%dT%H:%M:%S.%fZ")
+        return (now - updated_dt).days < MAX_REQUEST_AGE_DAYS
+
     ddb_table = ddb.Table(table)
 
     response = ddb_table.scan()
-    data = response["Items"]
+    data = [item for item in response["Items"] if is_recent(item)]
     while response.get("LastEvaluatedKey"):
         response = ddb_table.scan(ExclusiveStartKey=response["LastEvaluatedKey"])
-        data.extend(response["Items"])
+        data.extend([item for item in response["Items"] if is_recent(item)])
 
     logger.debug("Successful database scan of all egress requests")
     return data


### PR DESCRIPTION
# Description

Automatically omit egress requests updated more than 90 days ago from the API response to limit the size of the API body (AppSync has a 1MB limit).

Ideally the number of days should be configurable, but given the urgency of this change that can be added later.

This includes PR #11

---

Declaration : _By submitting this pull request, I confirm that my
contribution is made under the terms of the Apache-2.0 license_
